### PR TITLE
Fix WebSocket URL rewriting for pod logs

### DIFF
--- a/pkg/rancher-deskboard/index.ts
+++ b/pkg/rancher-deskboard/index.ts
@@ -1,5 +1,6 @@
 import { importTypes } from '@rancher/auto-import';
 import { IInternal, IPlugin } from '@shell/core/types';
+import Socket from '@shell/utils/socket';
 
 // Init the package
 export default function(plugin: IPlugin, internal: IInternal): void {
@@ -12,6 +13,7 @@ export default function(plugin: IPlugin, internal: IInternal): void {
   const { $axios, store, app: { router } } = internal;
 
   interceptApiRequest($axios);
+  interceptWebSocketUrls();
 
   let logoRoute = router.resolve({
     name: 'c-cluster-explorer',
@@ -33,12 +35,11 @@ export default function(plugin: IPlugin, internal: IInternal): void {
  * @param {*} axios The axios instance to modify
  */
 const interceptApiRequest = (axios: any) => {
-
   axios.interceptors.request.use((config: any) => {
     // ensure that http traffic to properly route to the proxy server
     if (config.url.includes(':6120')) {
       config.url = config.url
-        .replace('https://', 'http://')
+        .replace('https://', 'http://');
     }
 
     if (config.url.includes(':9443')) {
@@ -51,4 +52,42 @@ const interceptApiRequest = (axios: any) => {
   }, (error: any) => {
     return Promise.reject(error);
   });
+};
+
+/**
+ * Intercepts WebSocket URL construction to rewrite URLs for the proxy server.
+ *
+ * The dashboard runs on http://127.0.0.1:6120 (HTTP proxy) which proxies to
+ * https://127.0.0.1:9443 (Kubernetes API with TLS). WebSocket connections for
+ * pod logs/shell need to use ws:// (not wss://) when going through the proxy.
+ *
+ * This fixes issue #3212 where newly created pods fail to show logs because
+ * their WebSocket URLs use wss:// on the HTTP proxy port.
+ */
+const interceptWebSocketUrls = () => {
+  const originalSetUrl = Socket.prototype.setUrl;
+
+  Socket.prototype.setUrl = function(url: string) {
+    // Let the original setUrl process the URL first (handles relative URLs,
+    // protocol upgrades, etc.)
+    originalSetUrl.call(this, url);
+
+    // Now apply our transformations to this.url AFTER the original processing.
+    // The original setUrl upgrades ws:// to wss:// when served over HTTPS,
+    // so we need to fix it here.
+
+    // Route WebSocket traffic through the HTTP proxy on port 6120
+    // Convert wss://127.0.0.1:6120 → ws://127.0.0.1:6120
+    if (this.url.includes(':6120')) {
+      this.url = this.url.replace('wss://', 'ws://');
+    }
+
+    // Route direct API connections through the proxy
+    // Convert wss://127.0.0.1:9443 → ws://127.0.0.1:6120
+    if (this.url.includes(':9443')) {
+      this.url = this.url
+        .replace('wss://', 'ws://')
+        .replace(':9443', ':6120');
+    }
+  };
 };


### PR DESCRIPTION
The dashboard's axios interceptor rewrites HTTP URLs to route through the proxy server (port 6120), but WebSocket connections bypassed this interception entirely. This caused newly created pods to fail showing logs because their WebSocket URLs used `wss://` on the HTTP proxy port, resulting in SSL protocol errors.

Add interceptWebSocketUrls() that patches Socket.prototype.setUrl to apply the same URL rewriting logic for WebSocket connections:
- `wss://127.0.0.1:6120` → `ws://127.0.0.1:6120`
- `wss://127.0.0.1:9443` → `ws://127.0.0.1:6120`

Fixes rancher-sandbox/rancher-desktop#3212