### PR TITLE
Hide KubeConfig and Kubectl Shell buttons that don't work in Rancher Desktop

### DIFF
--- a/pkg/rancher-deskboard/index.ts
+++ b/pkg/rancher-deskboard/index.ts
@@ -25,6 +25,16 @@ export default function(plugin: IPlugin, internal: IInternal): void {
     logoRoute,
     logo: require(`./assets/logo.svg`),
   });
+
+  // Hide buttons in the header that don't work in Rancher Desktop.
+  // KubeConfig buttons don't function (issues #2208) and Kubectl Shell
+  // is not useful since users can use a local terminal (issue #8151).
+  store.commit('type-map/product', {
+    name:           'explorer',
+    hideKubeShell:  true,
+    hideKubeConfig: true,
+    hideCopyConfig: true,
+  });
 }
 
 /**


### PR DESCRIPTION
The Download/Copy KubeConfig buttons don't function and the Kubectl Shell button is not useful since users can use a local terminal.

<img width="790" height="110" alt="CleanShot 2026-01-07 at 23 19 27@2x" src="https://github.com/user-attachments/assets/1d4247a6-5d55-4bae-aaa5-776ef0a56c62" />


Fixes https://github.com/rancher-sandbox/rancher-desktop/issues/2208
Fixes https://github.com/rancher-sandbox/rancher-desktop/issues/8151